### PR TITLE
Python 3.2+ deprecated cgi.escape() for html.escape()

### DIFF
--- a/htmltmpl.py
+++ b/htmltmpl.py
@@ -50,12 +50,13 @@ INCLUDE_DIR = "inc"
 
 # Total number of possible parameters.
 # Increment if adding a parameter to any statement.
-PARAMS_NUMBER = 3
+PARAMS_NUMBER = 4
 
 # Relative positions of parameters in TemplateCompiler.tokenize().
 PARAM_NAME = 1
 PARAM_ESCAPE = 2
 PARAM_GLOBAL = 3
+PARAM_VALUE = 4
 PARAM_GETTEXT_STRING = 1
 
 # Find a way to lock files. Currently implemented only for UNIX and windows.
@@ -631,9 +632,11 @@ class TemplateProcessor:
                     if not var:
                         raise TemplateError("No identifier in <TMPL_IF>.")
                     globalp = tokens[i + PARAM_GLOBAL]
+                    valuep = tokens[i + PARAM_VALUE]
                     skip_params = 1
-                    if self.find_value(var, loop_name, loop_pass,
-                                       loop_total, globalp):
+                    valuef = self.find_value(var, loop_name, loop_pass,
+                                             loop_total, globalp)
+                    if valuef and (valuep is None or valuep == str(valuef)):
                         output_control.append(ENABLE_OUTPUT)
                         self.DEB("IF: ENABLE: " + str(var))
                     else:
@@ -1136,6 +1139,7 @@ class TemplateCompiler:
                 tokens.append(self.find_name(params))
                 tokens.append(self.find_param("ESCAPE", params))
                 tokens.append(self.find_param("GLOBAL", params))
+                tokens.append(self.find_param("VALUE", params))
             else:
                 # "Normal" template data.
                 if self._gettext:

--- a/htmltmpl.py
+++ b/htmltmpl.py
@@ -40,7 +40,7 @@ import os.path
 import pprint       # only for debugging
 import sys
 import copy
-import cgi          # for HTML escaping of variables
+import html          # for HTML escaping of variables
 import urllib.request, urllib.parse, urllib.error       # for URL escaping of variables
 import pickle      # for template compilation
 import gettext
@@ -892,7 +892,7 @@ class TemplateProcessor:
         ESCAPE_QUOTES = 1
         if (self._html_escape and override != "NONE" and override != "0" and \
             override != "URL") or override == "HTML" or override == "1":
-            return cgi.escape(str, ESCAPE_QUOTES)
+            return html.escape(str, ESCAPE_QUOTES)
         elif override == "URL":
             return urllib.parse.quote_plus(str)
         else:

--- a/test/if.py
+++ b/test/if.py
@@ -8,6 +8,7 @@ exec(compile(open("head.inc", "rb").read(), "head.inc", 'exec'))
 tproc.set("true", 1)
 tproc.set("false", 0)
 tproc.set("true2", 1)
+tproc.set("name", "value")
 
 #######################################################
 

--- a/test/if.res
+++ b/test/if.res
@@ -10,5 +10,7 @@
         
             <h1>++ IF true2</h1>
         
+            <h1>++ IF name=value</h1>
+        
     </body>
 </html>

--- a/test/if.tmpl
+++ b/test/if.tmpl
@@ -15,5 +15,8 @@
         <TMPL_IF true2>
             <h1>++ IF true2</h1>
         </TMPL_IF>        
+        <TMPL_IF NAME="name" VALUE="value">
+            <h1>++ IF name=value</h1>
+        </TMPL_IF>        
     </body>
 </html>


### PR DESCRIPTION
Python 3.2+ deprecated cgi.escape() for html.escape() and in 3.8
cgi.escape() has been completely removed.